### PR TITLE
fix: deduplicate goals in localStorage (#17)

### DIFF
--- a/lib/data-manager.ts
+++ b/lib/data-manager.ts
@@ -29,6 +29,51 @@ function getLocalGoals(): SavedGoal[] {
 	}
 }
 
+/**
+ * Deduplicate goals by dbId first, then by title+description signature.
+ * Keeps the goal with the most recent createdAt when duplicates exist.
+ */
+function deduplicateGoals(goals: SavedGoal[]): SavedGoal[] {
+	const seenDbIds = new Map<string, SavedGoal>()
+	const seenSignatures = new Map<string, SavedGoal>()
+	const result: SavedGoal[] = []
+
+	for (const goal of goals) {
+		// Dedup by dbId (prefer the one with later createdAt)
+		if (goal.dbId) {
+			const existing = seenDbIds.get(goal.dbId)
+			if (existing) {
+				if (new Date(goal.createdAt) > new Date(existing.createdAt)) {
+					// Replace the older one
+					const idx = result.indexOf(existing)
+					if (idx !== -1) result[idx] = goal
+					seenDbIds.set(goal.dbId, goal)
+				}
+				continue
+			}
+			seenDbIds.set(goal.dbId, goal)
+		}
+
+		// Dedup by signature for goals without dbId
+		const sig = goalSignature(goal.title, goal.description)
+		if (!goal.dbId) {
+			const existing = seenSignatures.get(sig)
+			if (existing) {
+				if (new Date(goal.createdAt) > new Date(existing.createdAt)) {
+					const idx = result.indexOf(existing)
+					if (idx !== -1) result[idx] = goal
+					seenSignatures.set(sig, goal)
+				}
+				continue
+			}
+		}
+		seenSignatures.set(sig, goal)
+		result.push(goal)
+	}
+
+	return result
+}
+
 function setLocalGoals(goals: SavedGoal[]): void {
 	if (typeof window === "undefined") return
 	localStorage.setItem(GOALS_KEY, JSON.stringify(goals))
@@ -270,9 +315,11 @@ export class GoalDataManager {
 				}
 			}
 
+			// --- Deduplicate after sync down ---
+			localGoals = deduplicateGoals(getLocalGoals())
+			setLocalGoals(localGoals)
+
 			// --- Sync UP: local → DB ---
-			// Re-read local goals (may have been mutated above)
-			localGoals = getLocalGoals()
 			const dbUuids = new Set(dbGoals.map(g => g.id))
 
 			for (const localGoal of localGoals) {
@@ -358,12 +405,18 @@ export class GoalDataManager {
 				dbGoalsBySignature.set(goalSignature(g.title, g.description), g.id)
 			}
 
+			// Deduplicate local goals before syncing
+			const dedupedLocalGoals = deduplicateGoals(localGoals)
+			if (dedupedLocalGoals.length < localGoals.length) {
+				setLocalGoals(dedupedLocalGoals)
+			}
+
 			let synced = 0
 			let skipped = 0
 			const errors: string[] = []
 
 			// Process each local goal
-			for (const localGoal of localGoals) {
+			for (const localGoal of dedupedLocalGoals) {
 				// Already linked to a DB record?
 				if (localGoal.dbId) {
 					skipped++
@@ -436,7 +489,13 @@ export class GoalDataManager {
 	// ----------------------------------------------------------------
 
 	async getGoals(): Promise<SavedGoal[]> {
-		return getLocalGoals()
+		const goals = getLocalGoals()
+		const deduped = deduplicateGoals(goals)
+		// If dedup removed any, persist the clean list
+		if (deduped.length < goals.length) {
+			setLocalGoals(deduped)
+		}
+		return deduped
 	}
 
 	async getGoalById(id: number | string): Promise<SavedGoal | null> {

--- a/lib/data-manager.ts
+++ b/lib/data-manager.ts
@@ -30,48 +30,45 @@ function getLocalGoals(): SavedGoal[] {
 }
 
 /**
- * Deduplicate goals by dbId first, then by title+description signature.
- * Keeps the goal with the most recent createdAt when duplicates exist.
+ * Deduplicate goals in two passes:
+ * 1. Group by title+description signature, keeping newest and preserving dbId.
+ * 2. Deduplicate by dbId (handles renamed goals pointing to the same DB record).
  */
 function deduplicateGoals(goals: SavedGoal[]): SavedGoal[] {
-	const seenDbIds = new Map<string, SavedGoal>()
-	const seenSignatures = new Map<string, SavedGoal>()
-	const result: SavedGoal[] = []
+	// Pass 1: deduplicate by signature, keep newest, merge dbId from either copy
+	const bySig = new Map<string, SavedGoal>()
 
 	for (const goal of goals) {
-		// Dedup by dbId (prefer the one with later createdAt)
-		if (goal.dbId) {
-			const existing = seenDbIds.get(goal.dbId)
-			if (existing) {
-				if (new Date(goal.createdAt) > new Date(existing.createdAt)) {
-					// Replace the older one
-					const idx = result.indexOf(existing)
-					if (idx !== -1) result[idx] = goal
-					seenDbIds.set(goal.dbId, goal)
-				}
-				continue
-			}
-			seenDbIds.set(goal.dbId, goal)
+		const sig = goalSignature(goal.title, goal.description)
+		const existing = bySig.get(sig)
+
+		if (!existing) {
+			bySig.set(sig, goal)
+			continue
 		}
 
-		// Dedup by signature for goals without dbId
-		const sig = goalSignature(goal.title, goal.description)
-		if (!goal.dbId) {
-			const existing = seenSignatures.get(sig)
-			if (existing) {
-				if (new Date(goal.createdAt) > new Date(existing.createdAt)) {
-					const idx = result.indexOf(existing)
-					if (idx !== -1) result[idx] = goal
-					seenSignatures.set(sig, goal)
-				}
-				continue
-			}
-		}
-		seenSignatures.set(sig, goal)
-		result.push(goal)
+		const winner = new Date(goal.createdAt) > new Date(existing.createdAt) ? goal : existing
+		const loser = winner === goal ? existing : goal
+		bySig.set(sig, { ...winner, dbId: winner.dbId || loser.dbId })
 	}
 
-	return result
+	// Pass 2: deduplicate by dbId (same DB record with different signatures)
+	const byDbId = new Map<string, SavedGoal>()
+	const noDbId: SavedGoal[] = []
+
+	for (const goal of bySig.values()) {
+		if (!goal.dbId) {
+			noDbId.push(goal)
+			continue
+		}
+
+		const existing = byDbId.get(goal.dbId)
+		if (!existing || new Date(goal.createdAt) > new Date(existing.createdAt)) {
+			byDbId.set(goal.dbId, goal)
+		}
+	}
+
+	return [...byDbId.values(), ...noDbId]
 }
 
 function setLocalGoals(goals: SavedGoal[]): void {


### PR DESCRIPTION
Fixes #17 (Goals are duplicating)

**Root cause:** Three paths where duplicates could accumulate:
1. `getGoals()` returned raw localStorage without dedup
2. `bidirectionalSync()` sync-down step could create new local entries for DB records that already matched an existing local goal by signature (the sig map only linked the first match)
3. `syncLocalGoalsToDatabase()` didn't clean up existing local duplicates before syncing

**Fix:** Added `deduplicateGoals()` that removes duplicates by `dbId` first, then by title+description signature (keeping the most recent `createdAt`). Applied at three points:
- `getGoals()` read path (auto-cleans on read, persists the deduped list)
- Post sync-down in `bidirectionalSync()`
- Pre-sync in `syncLocalGoalsToDatabase()`

Existing users with duplicated goals will have them cleaned up automatically on next page load.