### PR TITLE
fix: prevent duplicate creation in sync-down loop

### DIFF
--- a/lib/data-manager.ts
+++ b/lib/data-manager.ts
@@ -293,19 +293,34 @@ export class GoalDataManager {
 				const matchBySig = localBySig.get(sig)
 				if (matchBySig && !matchBySig.dbId) {
 					// Link the existing local goal to this DB record
+					matchBySig.dbId = dbUuid
 					updateLocalGoal(matchBySig.id, { dbId: dbUuid })
 					knownDbIds.add(dbUuid)
 					localByDbId.set(dbUuid, matchBySig)
+					// Update sig map so future goals with same sig don't re-match
+					localBySig.set(sig, matchBySig)
+					continue
+				}
+
+				// Check if we already pulled a goal with this same signature in a
+				// previous iteration of this loop (prevents creating duplicates when
+				// the DB has multiple records with identical title+description).
+				const existingBySig = localBySig.get(sig)
+				if (existingBySig && existingBySig.dbId) {
+					// Already have this content locally with a different dbId — skip
 					continue
 				}
 
 				// Truly new from DB — pull down
 				try {
-					localGoals = getLocalGoals() // re-read in case prior iteration mutated
 					const newId = generateNextId(localGoals)
 					const newLocal: SavedGoal = { ...dbGoal, id: newId, dbId: dbUuid }
 					localGoals.push(newLocal)
 					setLocalGoals(localGoals)
+					// Update all maps so subsequent iterations see this goal
+					knownDbIds.add(dbUuid)
+					localByDbId.set(dbUuid, newLocal)
+					localBySig.set(sig, newLocal)
 					result.dbToLocalSynced++
 				} catch (error) {
 					result.errors.push(`Failed to sync DB goal "${dbGoal.title}" locally: ${error instanceof Error ? error.message : String(error)}`)


### PR DESCRIPTION
Root cause fix for #17. The previous PR (#22) added deduplication as a safety net, but the actual bug was in `bidirectionalSync()`:

**Problem:** The sync-down loop built lookup maps (`knownDbIds`, `localByDbId`, `localBySig`) once before iterating, but never updated them as goals were added. This caused:
- DB goals with matching signatures to fall through to "truly new" because the sig map still pointed to a goal that already got linked
- Stale maps missing goals inserted in previous loop iterations
- A mid-loop `getLocalGoals()` re-read that bypassed the in-memory state entirely

**Fix:** Update all three maps after every link or insert operation. Skip DB goals whose signature already exists locally (handles DB-side duplicates). Remove the stale localStorage re-read.

The dedup function from PR #22 stays as a belt-and-suspenders guard.